### PR TITLE
update install script to install to ~/.local/bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown
 # Publish jobs to run in CI
 pr-run-mode = "plan"
 # Path that installers should place binaries in
-install-path = "CARGO_HOME"
+install-path = ["$BEAMUP_HOME/bin", "~/.local/bin"]
 # Whether to install an updater program
 install-updater = false
 


### PR DESCRIPTION
No option in cargo-dist to do something different on Windows so its stuck with `~/.local/bin` as well.

Resolves #52 